### PR TITLE
32 flaky test test end to end lan mlplan dummy network train config lan dummy generator config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,9 @@ dev = [
     "pre-commit>=2.20.0",
     "ptpython>=3.0.29",
     "pytest-cov>=6.1.1",
-    "pytest-xdist>=3.6.1",
+    "pytest-rerunfailures>=15.1",
     "pytest-timer>=1.0.0",
+    "pytest-xdist>=3.6.1",
     "pytest>=8.3.1",
     "ruff>=0.11.8",
 ]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -38,7 +38,7 @@ def dummy_training_data_files(generator_config, model_config, save=True):
         for file_ in os.listdir(generator_config["output_folder"])
     ]
 
-
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize(
     "train_type, config_fixture, generator_config_fixture",
     [

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -38,6 +38,7 @@ def dummy_training_data_files(generator_config, model_config, save=True):
         for file_ in os.listdir(generator_config["output_folder"])
     ]
 
+
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize(
     "train_type, config_fixture, generator_config_fixture",


### PR DESCRIPTION
This pull request updates dependencies in `pyproject.toml` and introduces a change in the test configuration to improve test reliability. The most important change is marking a test function as flaky with retry logic.

### Test configuration improvements:

* [`tests/test_end_to_end.py`](diffhunk://#diff-a4a614c9bc88758962ff69a4056481f9f9ae8930d92e4ce1ad8daab54a452b30L41-R41): Added `@pytest.mark.flaky(reruns=2)` to the `test_end_to_end_lan_mlp` test function to allow it to rerun up to two times in case of failure, improving test reliability.

### Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L62-R64): Added `pytest-rerunfailures>=15.1` in the dependency list.

