### PR TITLE
Update ssm-simulators dependency to version 0.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "frozendict >= 2.4.6",
     "onnx >= 1.17.0",
     "matplotlib >= 3.10.1",
-    "ssm-simulators >= 0.9.1",
+    "ssm-simulators >= 0.9.2",
 ]
 
 keywords = [


### PR DESCRIPTION
This pull request updates a dependency version in the `pyproject.toml` file to use ssm-simulators v0.9.2, which is v0.8.3 with CLI for data generation.

The change involves:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L36-R36): Updated the `ssm-simulators` dependency from version `0.9.1` to `0.9.2`.