### PR TITLE
Add transform-onnx script for converting TorchMLP models to ONNX format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,4 @@ line-length = 120
 [project.scripts]
 jaxtrain = "lanfactory.cli.jax_train:app"
 torchtrain = "lanfactory.cli.torch_train:app"
+transform-onnx = "lanfactory.onnx.transform_onnx:app"

--- a/src/lanfactory/onnx/transform_onnx.py
+++ b/src/lanfactory/onnx/transform_onnx.py
@@ -4,9 +4,10 @@ Can be run as a script.
 
 import pickle
 from typing import Any
-import argparse
 
 import torch
+import typer
+
 from lanfactory.trainers.torch_mlp import TorchMLP
 
 
@@ -47,18 +48,30 @@ def transform_to_onnx(
     torch.onnx.export(mynet, x, output_onnx_file)
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Convert a TorchMLP model to ONNX format.")
-    parser.add_argument("network_config_file", help="Path to the network configuration file (pickle).")
-    parser.add_argument("state_dict_file", help="Path to the state dictionary file.")
-    parser.add_argument("input_shape", type=int, help="Size of the input tensor for the model.")
-    parser.add_argument("output_onnx_file", help="Path to the output ONNX file.")
+app = typer.Typer()
 
-    args = parser.parse_args()
 
+def option_no_default(help: str) -> Any:
+    return typer.Option(..., help=help, show_default=False)
+
+
+@app.command()
+def main(
+    network_config_file: str = option_no_default("Path to the network configuration file (pickle)."),
+    state_dict_file: str = option_no_default("Path to the state dictionary file."),
+    input_shape: int = option_no_default("Size of the input tensor for the model."),
+    output_onnx_file: str = option_no_default("Path to the output ONNX file."),
+):
+    """
+    Convert a TorchMLP model to ONNX format.
+    """
     transform_to_onnx(
-        args.network_config_file,
-        args.state_dict_file,
-        args.input_shape,
-        args.output_onnx_file,
+        network_config_file,
+        state_dict_file,
+        input_shape,
+        output_onnx_file,
     )
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
This pull request introduces a new CLI command for transforming TorchMLP models to ONNX format and refactors the implementation to use `typer` instead of `argparse`. Key changes include adding the CLI entry point in `pyproject.toml`, replacing `argparse` with `typer`, and restructuring the main function for better usability.

### Addition of a new CLI command:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R102): Added a new script entry point `transform-onnx` to allow invoking the ONNX transformation functionality via the CLI.

### Refactoring to use `typer`:
* `src/lanfactory/onnx/transform_onnx.py`:
  * Replaced the `argparse`-based CLI implementation with `typer` for improved command-line interface design and type safety. [[1]](diffhunk://#diff-1c8d0115475d70d59bfc9ee68d1180c949214f703d8d86d3c8c232809c94a755L7-R10) [[2]](diffhunk://#diff-1c8d0115475d70d59bfc9ee68d1180c949214f703d8d86d3c8c232809c94a755L50-R77)
  * Introduced the `typer.Typer` app and defined a `main` command with explicit options for input parameters, enhancing clarity and user experience.