### PR TITLE
52 make jaxtrain/torchtrain config path optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ torchtrain --config-path config.yaml --training-data-folder my_generated_data --
 ```
 
 `jaxtrain` and `torchtrain` have the same 6 arguments
-* `--config-path`: Path to the YAML config file
+* `--config-path`: Path to the YAML config file (optional)
 * `--training-data-folder`: Path to folder with data to train the neural network on
 * `--networks-path-base`: Path to the output folder for trained neural network
 * `--network-id`: ID for the neural network to train (default: 0)
@@ -53,7 +53,7 @@ torchtrain --config-path config.yaml --training-data-folder my_generated_data --
 
 You can also view the help to see further documentation.
 
-Below is a sample configuration file you can use with `jaxtrain` or `torchtrain`.
+Below is a sample (default) configuration file you can use with `jaxtrain` or `torchtrain`.
 
 ```yaml
 NETWORK_TYPE: "lan"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,6 @@ line-length = 120
 jaxtrain = "lanfactory.cli.jax_train:app"
 torchtrain = "lanfactory.cli.torch_train:app"
 transform-onnx = "lanfactory.onnx.transform_onnx:app"
+
+[tool.setuptools.package-data]
+"lanfactory.cli" = ["config_network_training_lan.yaml"]

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -54,22 +54,7 @@ def main(
         autocompletion=lambda: ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
     ),
 ):
-    """Train a JAX neural network using the provided configuration.
-
-    Args:
-        config_path: Path to the YAML configuration file containing network and training settings
-        training_data_folder: Directory containing the training data files
-        network_id: ID of the specific network configuration to use from the config file
-        dl_workers: Number of worker processes for data loading. If <= 0, will use CPU count - 2
-        networks_path_base: Base directory to save trained networks and configs
-        log_level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-
-    The function:
-    1. Sets up logging and loads configuration
-    2. Prepares training and validation datasets
-    3. Initializes the JAX network and trainer
-    4. Trains the network and saves results
-    """
+    """Train a JAX neural network using the provided configuration."""
 
     # Set up logging ------------------------------------------------
     logging.basicConfig(

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -14,19 +14,20 @@ The main functionality includes:
 - Optional logging to Weights & Biases
 """
 
+import importlib.resources
 import logging
 import pickle  # convert to dill later
 import random
 import uuid
 from copy import deepcopy
 from pathlib import Path
-import typer
-import psutil
 
 import jax
-import torch
-
 import lanfactory
+import psutil
+import torch
+import typer
+
 from lanfactory.cli.utils import (
     _get_train_network_config,
 )

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -14,12 +14,12 @@ The main functionality includes:
 - Optional logging to Weights & Biases
 """
 
-import importlib.resources
 import logging
 import pickle  # convert to dill later
 import random
 import uuid
 from copy import deepcopy
+from importlib.resources import as_file, files
 from pathlib import Path
 
 import jax
@@ -27,7 +27,6 @@ import lanfactory
 import psutil
 import torch
 import typer
-
 from lanfactory.cli.utils import (
     _get_train_network_config,
 )

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -70,7 +70,7 @@ def main(
     logger.info("Number of workers we assign to the DataLoader: %d", n_workers)
 
     if config_path is None:
-        logger.info("No config path provided, using default configuration.")
+        logger.warning("No config path provided, using default configuration.")
         with as_file(files("lanfactory.cli") / "config_network_training_lan.yaml") as default_config:
             config_path = default_config
 

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -37,7 +37,7 @@ app = typer.Typer()
 
 @app.command()
 def main(
-    config_path: Path = typer.Option(..., help="Path to the YAML config file"),
+    config_path: Path = typer.Option(None, help="Path to the YAML config file"),
     training_data_folder: Path = typer.Option(..., help="Path to the training data folder"),
     network_id: int = typer.Option(0, help="Network ID to train"),
     dl_workers: int = typer.Option(1, help="Number of workers for DataLoader"),

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -70,7 +70,10 @@ def main(
 
     logger.info("Number of workers we assign to the DataLoader: %d", n_workers)
 
-    # Load config dict (new)
+    if config_path is None:
+        logger.info("No config path provided, using default configuration.")
+        with importlib.resources.path("lanfactory.cli", "config_network_training_lan.yaml") as default_config:
+            config_path = default_config
     config_dict = _get_train_network_config(yaml_config_path=str(config_path), net_index=network_id)
 
     logger.info("config dict keys: %s", config_dict.keys())

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -71,9 +71,13 @@ def main(
 
     if config_path is None:
         logger.info("No config path provided, using default configuration.")
-        with importlib.resources.path("lanfactory.cli", "config_network_training_lan.yaml") as default_config:
+        with as_file(files("lanfactory.cli") / "config_network_training_lan.yaml") as default_config:
             config_path = default_config
-    config_dict = _get_train_network_config(yaml_config_path=str(config_path), net_index=network_id)
+
+    config_dict = _get_train_network_config(
+        yaml_config_path=str(config_path),
+        net_index=network_id,
+    )
 
     logger.info("config dict keys: %s", config_dict.keys())
 

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -25,11 +25,11 @@ from pathlib import Path
 import jax
 import lanfactory
 import psutil
-import torch
 import typer
 from lanfactory.cli.utils import (
     _get_train_network_config,
 )
+from torch.utils.data import DataLoader
 
 app = typer.Typer()
 
@@ -119,7 +119,7 @@ def main(
         label_key=train_config["label_key"],
     )
 
-    dataloader_train = torch.utils.data.DataLoader(
+    dataloader_train = DataLoader(
         train_dataset,
         shuffle=train_config["shuffle_files"],
         batch_size=None,
@@ -135,7 +135,7 @@ def main(
         label_key=train_config["label_key"],
     )
 
-    dataloader_val = torch.utils.data.DataLoader(
+    dataloader_val = DataLoader(
         val_dataset,
         shuffle=train_config["shuffle_files"],
         batch_size=None,

--- a/src/lanfactory/cli/torch_train.py
+++ b/src/lanfactory/cli/torch_train.py
@@ -14,15 +14,17 @@ The main functionality includes:
 - Optional logging to Weights & Biases
 """
 
-import random
 import logging
-from pathlib import Path
+import pickle
+import random
 import uuid
 from copy import deepcopy
-import pickle
+from importlib.resources import as_file, files
+from pathlib import Path
+
+import psutil
 import torch
 import typer
-import psutil
 
 import lanfactory
 from lanfactory.cli.utils import (

--- a/src/lanfactory/cli/torch_train.py
+++ b/src/lanfactory/cli/torch_train.py
@@ -53,22 +53,7 @@ def main(
         autocompletion=lambda: ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
     ),
 ):
-    """Train a JAX neural network using the provided configuration.
-
-    Args:
-        config_path: Path to the YAML configuration file containing network and training settings
-        training_data_folder: Directory containing the training data files
-        network_id: ID of the specific network configuration to use from the config file
-        dl_workers: Number of worker processes for data loading. If <= 0, will use CPU count - 2
-        networks_path_base: Base directory to save trained networks and configs
-        log_level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-
-    The function:
-    1. Sets up logging and loads configuration
-    2. Prepares training and validation datasets
-    3. Initializes the JAX network and trainer
-    4. Trains the network and saves results
-    """
+    """Train a JAX neural network using the provided configuration."""
 
     # Set up logging ------------------------------------------------
     logging.basicConfig(

--- a/src/lanfactory/cli/torch_train.py
+++ b/src/lanfactory/cli/torch_train.py
@@ -69,7 +69,11 @@ def main(
 
     logger.info("Number of workers we assign to the DataLoader: %d", n_workers)
 
-    # Load config dict (new)
+    if config_path is None:
+        logger.warning("No config path provided, using default configuration.")
+        with as_file(files("lanfactory.cli") / "config_network_training_lan.yaml") as default_config:
+            config_path = default_config
+
     if network_id is None:
         config_dict = _get_train_network_config(yaml_config_path=config_path, net_index=0)
     else:

--- a/src/lanfactory/cli/torch_train.py
+++ b/src/lanfactory/cli/torch_train.py
@@ -36,7 +36,7 @@ app = typer.Typer()
 
 @app.command()
 def main(
-    config_path: Path = typer.Option(..., help="Path to the YAML config file"),
+    config_path: Path = typer.Option(None, help="Path to the YAML config file"),
     training_data_folder: Path = typer.Option(..., help="Path to the training data folder"),
     networks_path_base: Path = typer.Option(..., help="Base path for networks"),
     network_id: int = typer.Option(0, help="Network ID to train"),

--- a/tests/cli/test_cli_entry_points.py
+++ b/tests/cli/test_cli_entry_points.py
@@ -1,8 +1,11 @@
 import subprocess
 from pathlib import Path
 
+import pytest
 
-def test_jax_train_cli_smoke(tmp_path):
+
+@pytest.mark.parametrize("with_config", [True, False])
+def test_jax_train_cli_smoke(tmp_path, with_config):
     """Smoke test: actually runs the CLI with real data."""
     # Path to the training data directory
     __dir__ = Path(__file__).parent
@@ -15,6 +18,7 @@ def test_jax_train_cli_smoke(tmp_path):
     networks_path = tmp_path / "networks"
     networks_path.mkdir()
 
+    # Build command based on parameter
     cmd = [
         "jaxtrain",
         "--training-data-folder",
@@ -23,15 +27,10 @@ def test_jax_train_cli_smoke(tmp_path):
         str(networks_path),
         "--log-level",
         "WARNING",
-        "--config-path",
-        config_path,
     ]
-
+    if with_config:
+        cmd += ["--config-path", config_path]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    assert result.returncode == 0, f"jax_train.py failed: {result.stderr}"
-
-    # No config path provided, should use default config
-    result = subprocess.run(cmd[:-2], capture_output=True, text=True, check=False)
     assert result.returncode == 0, f"jax_train.py failed: {result.stderr}"
 
 

--- a/tests/cli/test_cli_entry_points.py
+++ b/tests/cli/test_cli_entry_points.py
@@ -30,6 +30,10 @@ def test_jax_train_cli_smoke(tmp_path):
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     assert result.returncode == 0, f"jax_train.py failed: {result.stderr}"
 
+    # No config path provided, should use default config
+    result = subprocess.run(cmd[:-2], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, f"jax_train.py failed: {result.stderr}"
+
 
 def test_torch_train_cli_smoke(tmp_path):
     """Smoke test: actually runs the CLI with real data."""

--- a/tests/cli/test_cli_entry_points.py
+++ b/tests/cli/test_cli_entry_points.py
@@ -17,14 +17,14 @@ def test_jax_train_cli_smoke(tmp_path):
 
     cmd = [
         "jaxtrain",
-        "--config-path",
-        config_path,
         "--training-data-folder",
         training_data_folder,
         "--networks-path-base",
         str(networks_path),
         "--log-level",
         "WARNING",
+        "--config-path",
+        config_path,
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)


### PR DESCRIPTION
This pull request introduces support for using a default configuration file when no config path is provided to the `jaxtrain` and `torchtrain` CLI commands. It updates both the implementation and documentation to reflect this change, and ensures the default config file is included in the package distribution. The most important changes are grouped below by theme.

**Default configuration support in CLI commands:**

* Both `src/lanfactory/cli/jax_train.py` and `src/lanfactory/cli/torch_train.py` now accept an optional `--config-path` argument. If not provided, a bundled default configuration file (`config_network_training_lan.yaml`) is used via `importlib.resources`. [[1]](diffhunk://#diff-9e58ec6b139e2a170636e7a662abae37c8ab43281b79c4c238d449ed6bf6c6b8L39-R39) [[2]](diffhunk://#diff-9e58ec6b139e2a170636e7a662abae37c8ab43281b79c4c238d449ed6bf6c6b8L87-R80) [[3]](diffhunk://#diff-dbe36dd4866ea43c7d0d6d2c22314a5ceb4a5f20f4d2e47a96c5c7f4674ffa96L37-R39) [[4]](diffhunk://#diff-dbe36dd4866ea43c7d0d6d2c22314a5ceb4a5f20f4d2e47a96c5c7f4674ffa96L85-R76)
* The implementation for loading the configuration was updated to handle the default file when `config_path` is `None`, and appropriate logging was added to inform the user. [[1]](diffhunk://#diff-9e58ec6b139e2a170636e7a662abae37c8ab43281b79c4c238d449ed6bf6c6b8L87-R80) [[2]](diffhunk://#diff-dbe36dd4866ea43c7d0d6d2c22314a5ceb4a5f20f4d2e47a96c5c7f4674ffa96L85-R76)

**Documentation updates:**

* The `README.md` clarifies that `--config-path` is now optional and refers to the sample configuration file as the default. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R47) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R56)

**Packaging changes:**

* The default configuration file is included in the Python package via the `[tool.setuptools.package-data]` section in `pyproject.toml`, ensuring it is available at runtime.

**Testing improvements:**

* The CLI smoke tests in `tests/cli/test_cli_entry_points.py` now verify that both explicit and default config file usage work for `jaxtrain`.

**Code cleanup:**

* The docstrings for the CLI entry points were shortened to reflect the simplified configuration logic. [[1]](diffhunk://#diff-9e58ec6b139e2a170636e7a662abae37c8ab43281b79c4c238d449ed6bf6c6b8L56-R56) [[2]](diffhunk://#diff-dbe36dd4866ea43c7d0d6d2c22314a5ceb4a5f20f4d2e47a96c5c7f4674ffa96L54-R56)