### PR TITLE
Bump version from 0.5.3 to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "lanfactory"
-version = "0.5.3"
+version = "0.6.0"
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },
     { name = "Carlos Paniagua", email = "carlos_paniagua@brown.edu" },


### PR DESCRIPTION
This pull request updates the project version in `pyproject.toml` to reflect a new release.

* Project metadata update:
  * Bumped the `version` field from `0.5.3` to `0.6.0` in `pyproject.toml`, indicating a new release of the `lanfactory` package.