### PR TITLE
fix(hf): reject a non-mapping architecture/training in model_card.yaml

### DIFF
--- a/src/lanfactory/hf/model_card.py
+++ b/src/lanfactory/hf/model_card.py
@@ -52,6 +52,24 @@ class ModelCardConfig:
     usage_example: str | None = None
 
 
+def _require_mapping(data: dict, key: str, yaml_path: Path) -> dict | None:
+    """Return ``data[key]`` when it is a mapping (or absent), else raise.
+
+    Both ``architecture`` and ``training`` are consumed with ``.get()`` during
+    README generation. A wrong shape here is otherwise only discovered there --
+    after the artifact upload has already started -- and it silently suppresses
+    the pickle fallback, since a bad value is still not ``None``.
+    """
+    value = data.get(key)
+    if value is None or isinstance(value, dict):
+        return value
+    raise ValueError(
+        f"{yaml_path}: '{key}' must be a mapping, got {type(value).__name__}. "
+        "Omit it to have LANfactory fill it in from the pickled configs, which "
+        "are the authoritative record of what was trained."
+    )
+
+
 def load_model_card_yaml(model_folder: Path) -> ModelCardConfig:
     """Load model card configuration from YAML file.
 
@@ -69,6 +87,8 @@ def load_model_card_yaml(model_folder: Path) -> ModelCardConfig:
     ------
     FileNotFoundError
         If model_card.yaml is not found in the model folder.
+    ValueError
+        If 'architecture' or 'training' is present but is not a mapping.
     """
     yaml_path = model_folder / "model_card.yaml"
 
@@ -90,8 +110,8 @@ def load_model_card_yaml(model_folder: Path) -> ModelCardConfig:
         description=data.get(
             "description", "Likelihood Approximation Network trained with LANfactory."
         ),
-        architecture=data.get("architecture"),
-        training=data.get("training"),
+        architecture=_require_mapping(data, "architecture", yaml_path),
+        training=_require_mapping(data, "training", yaml_path),
         usage_example=data.get("usage_example"),
     )
 

--- a/tests/hf/test_model_card.py
+++ b/tests/hf/test_model_card.py
@@ -111,6 +111,21 @@ class TestLoadModelCardYaml:
         assert config.architecture["layer_sizes"] == [100, 100, 1]
         assert config.architecture["network_type"] == "lan"
 
+    @pytest.mark.parametrize("key", ["architecture", "training"])
+    def test_load_yaml_rejects_non_mapping(self, key, tmp_path):
+        """A wrong shape must fail here, not deep inside README generation.
+
+        A list is the plausible mistake -- `architecture: [100, 100, 1]` reads
+        naturally -- and it used to survive load, suppress the pickle fallback,
+        and only blow up on `.get()` after the upload had begun.
+        """
+        yaml_path = tmp_path / "model_card.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump({"title": "Test Model", key: [100, 100, 1]}, f)
+
+        with pytest.raises(ValueError, match=f"'{key}' must be a mapping"):
+            load_model_card_yaml(tmp_path)
+
 
 class TestGenerateReadme:
     """Tests for generate_readme function."""


### PR DESCRIPTION
## What

`ModelCardConfig.architecture` and `.training` are typed `dict | None` and read with `.get()` in `generate_readme`, but `load_model_card_yaml` accepted whatever the YAML held.

A list — `architecture: [100, 100, 1]`, which reads naturally enough to write by hand — did two bad things at once:

1. It was not `None`, so `_fill_from_pickle_configs` **skipped** the fallback that would have supplied the correct dict from `*_network_config.pickle`.
2. It surfaced only at `config.architecture.get("network_type")` inside `write_readme` — as `AttributeError: 'list' object has no attribute 'get'`, **after** the artifact upload had already started, leaving a half-populated staging dir and a partial remote commit.

## Change

One helper, called on the two dict-typed fields at load time:

```
ValueError: /path/model_card.yaml: 'architecture' must be a mapping, got list.
Omit it to have LANfactory fill it in from the pickled configs, which are the
authoritative record of what was trained.
```

The message points at the right fix rather than just the wrong type — omitting the field is better than restating it, since a hand-written copy can drift from the pickle.

## Scope

Deliberately narrow: only the two fields that crash. `tags` / `usage_example` are formatted, not traversed, so a wrong type there degrades a string instead of raising.

## Testing

`tests/hf/test_model_card.py` — one parametrized case over both fields. Verified it fails on `main` (`AttributeError` path) and passes with the change. Full file: 23 passed; ruff check + format clean.

Found while publishing a `gamma_drift_angle` LAN to `franklab/HSSM_staging`; the publisher's dry run does not reach README generation, so nothing caught it before the upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model card loading now clearly reports invalid `architecture` or `training` YAML values instead of failing later during README generation.
  * Invalid list-based values are rejected before fallback processing occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->