### PR TITLE
feat(hf): publish recovery_report.json alongside the network

### DIFF
--- a/src/lanfactory/hf/upload.py
+++ b/src/lanfactory/hf/upload.py
@@ -22,6 +22,11 @@ DEFAULT_INCLUDE_PATTERNS = [
     "*_config.pickle",
     "*_data_details.pickle",
     "validation_report.json",
+    # The gate report says the network is structurally sound; this one says
+    # whether anyone could recover parameters with it. Without it the only
+    # quality evidence that travels with an artifact is the gate, which cannot
+    # see a recovery failure at all.
+    "recovery_report.json",
     "*.csv",
     "model_card.yaml",
 ]

--- a/tests/hf/test_dual_layout.py
+++ b/tests/hf/test_dual_layout.py
@@ -37,6 +37,7 @@ def model_folder(tmp_path):
     (folder / "abc123_lan_ddm__network_config.pickle").write_bytes(b"pickle")
     (folder / "abc123_lan_ddm__data_details.pickle").write_bytes(b"pickle")
     (folder / "validation_report.json").write_text('{"gates": {}}')
+    (folder / "recovery_report.json").write_text('{"passed": false}')
     (folder / "abc123_lan_ddm__training_history.csv").write_text("epoch,loss\n")
     return folder
 
@@ -344,6 +345,9 @@ class TestDryRunReporting:
         out = capsys.readouterr().out
         assert "abc123_lan_ddm__data_details.pickle" in out
         assert "validation_report.json" in out
+        # The gate report cannot see a recovery failure; a network whose
+        # recovery verdict is false would otherwise ship looking clean.
+        assert "recovery_report.json" in out
 
 
 class TestUploadCommit:


### PR DESCRIPTION
`recovery_report.json` was missing from `DEFAULT_INCLUDE_PATTERNS`, so it never reached the Hub.

That matters because the two reports answer different questions. `validation_report.json` says the artifact is structurally sound, loads in HSSM, and produces a plausible density. It **cannot see a recovery failure** — the gate has no recovery check in it. So a network whose parameter-recovery verdict is `passed: false` ships looking entirely clean, and the only quality evidence a downstream reader gets is the one that could not have detected the problem.

Concretely: `gamma_drift_angle` is on `franklab/HSSM_staging` with `validation_report.json` reporting all gates passed, while its standalone recovery verdict is `passed: false` (2 coverage failures, 3 bias-rate failures). Nothing in the published bundle says so.

One line in the include patterns, plus fixture and assertion in `test_dual_layout.py`.

96 passed, 1 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)