### PR TITLE
Move linting/formatting check into separate CI workflow

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -26,8 +26,13 @@ jobs:
       contents: read
     uses: ./.github/workflows/run_tests.yml
 
+  lint:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/linting_formatting.yml
+
   report:
-    needs: [tests]
+    needs: [tests, lint]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -43,6 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RESULT_TESTS: ${{ needs.tests.result }}
+          RESULT_LINT: ${{ needs.lint.result }}
           FORCE_FAIL: ${{ inputs.force_fail }}
         run: |
           set -euo pipefail
@@ -53,6 +59,9 @@ jobs:
           FAILED_JOBS=""
           if [ "$RESULT_TESTS" = "failure" ]; then
             FAILED_JOBS=" tests"
+          fi
+          if [ "$RESULT_LINT" = "failure" ]; then
+            FAILED_JOBS="$FAILED_JOBS lint"
           fi
           if [ "$FORCE_FAIL" = "true" ]; then
             FAILED_JOBS="$FAILED_JOBS (force_fail rehearsal)"
@@ -67,13 +76,13 @@ jobs:
           # never-started test job is no evidence of health — treating it as
           # green would silently retire a real drift issue.
           if [ -z "$FAILED_JOBS" ]; then
-            if [ "$RESULT_TESTS" = "success" ]; then
+            if [ "$RESULT_TESTS" = "success" ] && [ "$RESULT_LINT" = "success" ]; then
               if [ -n "$EXISTING" ]; then
                 gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
                   --comment "Scheduled drift checks green again: $RUN_URL"
               fi
             else
-              echo "::notice::Inconclusive run (tests: $RESULT_TESTS) —" \
+              echo "::notice::Inconclusive run (tests: $RESULT_TESTS, lint: $RESULT_LINT) —" \
                 "drift issue state left unchanged."
             fi
             exit 0

--- a/.github/workflows/linting_formatting.yml
+++ b/.github/workflows/linting_formatting.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_call: # Called by drift.yml (scheduled drift detection)
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting_formatting.yml
+++ b/.github/workflows/linting_formatting.yml
@@ -13,20 +13,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
 
-      - name: Install package
-        run: uv sync --group dev
+      - name: Install lint dependencies
+        run: uv sync --only-group lint --no-install-project
 
       - name: Check styling
         run: uv run ruff format --check .

--- a/.github/workflows/linting_formatting.yml
+++ b/.github/workflows/linting_formatting.yml
@@ -25,7 +25,7 @@ jobs:
         run: uv sync --only-group lint --no-install-project
 
       - name: Check styling
-        run: uv run ruff format --check .
+        run: uv run --no-sync ruff format --check .
 
       - name: Linting
-        run: uv run ruff check src/lanfactory
+        run: uv run --no-sync ruff check src/lanfactory

--- a/.github/workflows/linting_formatting.yml
+++ b/.github/workflows/linting_formatting.yml
@@ -2,6 +2,7 @@ name: Linting and Formatting
 
 on:
   pull_request:
+  workflow_call: # Called by drift.yml (scheduled drift detection)
 
 jobs:
   lint:

--- a/.github/workflows/linting_formatting.yml
+++ b/.github/workflows/linting_formatting.yml
@@ -1,0 +1,34 @@
+name: Linting and Formatting
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install package
+        run: uv sync --group dev
+
+      - name: Check styling
+        run: uv run ruff format --check .
+
+      - name: Linting
+        run: uv run ruff check src/lanfactory

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,12 +45,6 @@ jobs:
       - name: Run pytest
         run: uv run pytest
 
-      - name: Check styling
-        run: uv run ruff format --check .
-
-      - name: Linting
-        run: uv run ruff check src/lanfactory
-
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,11 @@ all = [
 ]
 
 [dependency-groups]
+lint = [
+    # <0.16: ruff 0.16 flags ~111 pre-existing errors repo-wide (same drift that
+    # broke ssm-simulators CI, pinned identically there); migrate deliberately.
+    "ruff>=0.15.1,<0.16",
+]
 dev = [
     "coverage>=7.6.4",
     "ipykernel>=6.29.5",
@@ -87,9 +92,7 @@ dev = [
     "pytest-timer>=1.0.0",
     "pytest-xdist>=3.6.1",
     "pytest>=8.3.1",
-    # <0.16: ruff 0.16 flags ~111 pre-existing errors repo-wide (same drift that
-    # broke ssm-simulators CI, pinned identically there); migrate deliberately.
-    "ruff>=0.15.1,<0.16",
+    { include-group = "lint" },
     "types-PyYAML",
     "mlflow>=3.14.0",
     "jaxonnxruntime>=0.3",


### PR DESCRIPTION
This pull request refactors the project's GitHub Actions workflows by separating linting and formatting checks into a dedicated workflow. The main test workflow (`run_tests.yml`) is now focused solely on running tests and uploading coverage, while all code style and linting checks are handled in a new workflow.

**Workflow improvements:**

* Created a new workflow file, `.github/workflows/linting_formatting.yml`, to run linting and formatting checks using `ruff` and `uv`.
* Removed linting and formatting steps from the main test workflow, `.github/workflows/run_tests.yml`, to avoid redundancy and streamline responsibilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a dedicated automated linting and formatting workflow for pull requests and reusable CI runs.
  - Integrated linting results into drift monitoring alongside the test matrix.
  - Updated drift reporting to close issues only when both tests and lint checks succeed.
  - Streamlined the test workflow by removing duplicate formatting and linting steps.
  - Organized linting tools into a dedicated development dependency group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->