### PR TITLE
fix(trainers): update training history indexing to use iloc

### DIFF
--- a/src/lanfactory/trainers/jax_mlp.py
+++ b/src/lanfactory/trainers/jax_mlp.py
@@ -3,20 +3,22 @@ are used to train Jax based LANs and CPNs.
 """
 
 import pickle
+from collections.abc import Callable, Sequence
 from functools import partial
 from pathlib import Path
 from time import time
-from typing import Any, Callable, Sequence
+from typing import Any
 
 import flax
 import jax
 import numpy as np
 import optax
-import pandas as pd
 from flax import linen as nn
 from flax.training import train_state
 from frozendict import frozendict
 from jax import numpy as jnp
+
+from lanfactory.utils.util_funs import _create_training_history
 
 try:
     import mlflow
@@ -134,7 +136,7 @@ class JaxMLP(nn.Module):
         if (not self.train) and (self.train_output_type == "logprob"):
             x = x  # just for pedagogy
         elif (not self.train) and (self.train_output_type == "logits"):
-            x = -jnp.log((1 + jnp.exp(-x)))
+            x = -jnp.log(1 + jnp.exp(-x))
         elif not self.train:  # pragma: no cover
             x = x  # just for pedagogy
 
@@ -272,7 +274,7 @@ class ModelTrainerJaxMLP:
                 The ModelTrainerJaxMLP object.
 
         """
-        if "loss_dict" not in train_config.keys():
+        if "loss_dict" not in train_config:
             self.loss_dict: dict[str, dict] = {
                 "huber": {"fun": optax.huber_loss, "kwargs": {"delta": 1}},
                 "mse": {"fun": optax.l2_loss, "kwargs": {}},
@@ -281,7 +283,7 @@ class ModelTrainerJaxMLP:
         else:  # pragma: no cover
             self.loss_dict = train_config["loss_dict"]
 
-        if "lr_dict" not in train_config.keys():
+        if "lr_dict" not in train_config:
             # Todo: Add more schedules (for now warmup_cosine_decay_schedule)
             self.lr_dict: dict[str, float] = {
                 "init_value": 0.0002,
@@ -556,9 +558,7 @@ class ModelTrainerJaxMLP:
                 )
 
         # Initialize Training history
-        training_history = pd.DataFrame(
-            np.zeros((self.train_config["n_epochs"], 2)), columns=["epoch", "val_loss"]
-        )
+        training_history = _create_training_history(self.train_config["n_epochs"])
 
         # Initialize network
         if not isinstance(self.seed, int):

--- a/src/lanfactory/trainers/jax_mlp.py
+++ b/src/lanfactory/trainers/jax_mlp.py
@@ -592,7 +592,7 @@ class ModelTrainerJaxMLP:
             )
 
             # Collect loss in training history
-            training_history.values[epoch, :] = [int(epoch), float(test_loss)]
+            training_history.iloc[epoch] = [int(epoch), float(test_loss)]
 
             if self.mlflow_on:
                 try:

--- a/src/lanfactory/trainers/torch_mlp.py
+++ b/src/lanfactory/trainers/torch_mlp.py
@@ -820,7 +820,7 @@ class ModelTrainerTorchMLP:
                     self.scheduler.step()
 
             # Append training history
-            training_history.values[epoch, :] = [epoch, val_loss.cpu()]
+            training_history.iloc[epoch] = [int(epoch), float(val_loss.cpu())]
 
             if mlflow_on:
                 try:

--- a/src/lanfactory/trainers/torch_mlp.py
+++ b/src/lanfactory/trainers/torch_mlp.py
@@ -1,19 +1,19 @@
 """This module contains the classes for training TorchMLP models."""
 
+import logging
+import pickle
+from collections.abc import Callable
+from pathlib import Path
+from time import time
+
 import numpy as np
 import pandas as pd
-import pickle
-from typing import Callable
-from time import time
-import logging
-from pathlib import Path
-
-
 import torch
-import torch.nn as nn
-import torch.optim as optim
 import torch.nn.functional as F
+from torch import nn, optim
 from torch.utils.data import DataLoader
+
+from lanfactory.utils.util_funs import _create_training_history
 
 try:
     import mlflow
@@ -126,7 +126,6 @@ class DatasetTorch(torch.utils.data.Dataset):
         ]
         self.tmp_data[self.label_key] = self.tmp_data[self.label_key][shuffle_idx]
         self.__apply_label_bounds()
-        return
 
     def __init_file_shape(self) -> None:
         # Function gets dimensionalities form a test data file
@@ -164,7 +163,6 @@ class DatasetTorch(torch.utils.data.Dataset):
             self.label_dim = self.file_shape_dict["labels"][1]
         else:
             self.label_dim = 1
-        return
 
     def __data_generation(
         self, batch_ids: np.ndarray | slice | None = None
@@ -384,7 +382,7 @@ def TorchMLPFactory(
     """
     if isinstance(network_config, str):
         with open(network_config, "rb") as f:
-            network_config = pickle.load(f)  # noqa: S301
+            network_config = pickle.load(f)
 
     assert isinstance(network_config, dict)
     return TorchMLP(
@@ -413,7 +411,7 @@ class TorchMLP(nn.Module):
         input_shape: int = 10,
         network_type: str | None = None,
     ) -> None:
-        super(TorchMLP, self).__init__()
+        super().__init__()
 
         self.input_shape = input_shape
         self.network_config = network_config
@@ -499,7 +497,7 @@ class TorchMLP(nn.Module):
             return self.layers[-1](x)
         elif self.train_output_type == "logits":
             return -torch.log(
-                (1 + torch.exp(-self.layers[-1](x)))
+                1 + torch.exp(-self.layers[-1](x))
             )  # log ( 1 / (1 + exp(-x))), where x = log(p / (1 - p))
         else:
             return self.layers[-1](x)
@@ -548,7 +546,7 @@ class ModelTrainerTorchMLP:
                 self.train_config: dict = pickle.load(open(train_config, "rb"))
             except (OSError, pickle.PickleError) as e:  # pragma: no cover
                 logger.error(
-                    f"Error loading training config from file {train_config}: {str(e)}"
+                    f"Error loading training config from file {train_config}: {e!s}"
                 )
                 raise
         elif isinstance(train_config, dict):
@@ -625,37 +623,23 @@ class ModelTrainerTorchMLP:
                 self.scheduler = optim.lr_scheduler.ReduceLROnPlateau(
                     self.optimizer,
                     mode="min",
-                    factor=(
-                        self.train_config["lr_scheduler_params"]["factor"]
-                        if "factor" in self.train_config["lr_scheduler_params"]
-                        else 0.1
+                    factor=self.train_config["lr_scheduler_params"].get("factor", 0.1),
+                    patience=self.train_config["lr_scheduler_params"].get(
+                        "patience", 2
                     ),
-                    patience=(
-                        self.train_config["lr_scheduler_params"]["patience"]
-                        if "patience" in self.train_config["lr_scheduler_params"]
-                        else 2
-                    ),
-                    threshold=(
-                        self.train_config["lr_scheduler_params"]["threshold"]
-                        if "threshold" in self.train_config["lr_scheduler_params"]
-                        else 0.001
+                    threshold=self.train_config["lr_scheduler_params"].get(
+                        "threshold", 0.001
                     ),
                     threshold_mode="rel",
                     cooldown=0,
-                    min_lr=(
-                        self.train_config["lr_scheduler_params"]["min_lr"]
-                        if "min_lr" in self.train_config["lr_scheduler_params"]
-                        else 0.00000001
+                    min_lr=self.train_config["lr_scheduler_params"].get(
+                        "min_lr", 0.00000001
                     ),
                 )
             elif self.train_config["lr_scheduler"] == "multiply":
                 self.scheduler = optim.lr_scheduler.ExponentialLR(
                     self.optimizer,
-                    gamma=(
-                        self.train_config["lr_scheduler_params"]["factor"]
-                        if "factor" in self.train_config["lr_scheduler_params"]
-                        else 0.1
-                    ),
+                    gamma=self.train_config["lr_scheduler_params"].get("factor", 0.1),
                     last_epoch=-1,
                 )
             elif self.train_config["lr_scheduler"] == "cosine":
@@ -747,9 +731,7 @@ class ModelTrainerTorchMLP:
         if mlflow_on:
             self.__try_mlflow(run_id=run_id)
 
-        training_history: pd.DataFrame = pd.DataFrame(
-            np.zeros((self.train_config["n_epochs"], 2)), columns=["epoch", "val_loss"]
-        )
+        training_history = _create_training_history(self.train_config["n_epochs"])
 
         step_cnt = 0
         self.model.train()
@@ -820,7 +802,7 @@ class ModelTrainerTorchMLP:
                     self.scheduler.step()
 
             # Append training history
-            training_history.iloc[epoch] = [int(epoch), float(val_loss.cpu())]
+            training_history.iloc[epoch] = [int(epoch), val_loss.item()]
 
             if mlflow_on:
                 try:

--- a/src/lanfactory/utils/util_funs.py
+++ b/src/lanfactory/utils/util_funs.py
@@ -3,6 +3,19 @@
 import pickle
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
+
+
+def _create_training_history(n_epochs: int) -> pd.DataFrame:
+    """Create an empty training history with stable column dtypes."""
+    return pd.DataFrame(
+        {
+            "epoch": np.zeros(n_epochs, dtype=int),
+            "val_loss": np.zeros(n_epochs),
+        }
+    )
+
 
 def save_configs(
     model_id: str | None = None,
@@ -38,4 +51,3 @@ def save_configs(
         train_config, open(Path(save_folder) / f"{model_id}_train_config.pickle", "wb")
     )
     print("Saved train config")
-    return


### PR DESCRIPTION
This pull request updates how training history is recorded in both the JAX and PyTorch MLP trainers to improve compatibility with pandas DataFrames. Specifically, it replaces direct assignment to the `.values` attribute with assignment via `.iloc`, and ensures data types are consistent.

Training history recording updates:

* In `src/lanfactory/trainers/jax_mlp.py`, changed assignment from `training_history.values[epoch, :]` to `training_history.iloc[epoch]` and explicitly cast values to `int` and `float` for better pandas compatibility.
* In `src/lanfactory/trainers/torch_mlp.py`, updated training history assignment to use `training_history.iloc[epoch]` with explicit type casting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording of per-epoch training and validation history during JAX and PyTorch model training.
  * Training history now consistently stores epoch numbers and validation losses in the expected formats.
  * Improved handling of optional learning-rate scheduler settings, including default values when settings are not provided.
  * Improved configuration-loading error reporting during PyTorch model setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->