### PR TITLE
Fix/mlflow shared server prep

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -20,12 +20,13 @@ Train a JAX network. Either `--training-data-folder` or
 | `--networks-path-base PATH` | required | Base directory for saved network artifacts |
 | `--dry-run` | off | Validate configuration and data discovery without training |
 | `--export-onnx` / `--no-export-onnx` | on | Export the HSSM-consumable ONNX artifact after training |
+| `--mlflow` / `--no-mlflow` | auto | Force tracking on or off; when omitted, tracking is on if any `--mlflow-*` option, `--data-generation-experiment-id`, or `MLFLOW_TRACKING_URI` is set |
 | `--mlflow-run-name TEXT` | unset | Enable tracking under this run name |
 | `--mlflow-experiment-name TEXT` | `MLFLOW_EXPERIMENT_NAME` or unset | MLflow experiment name |
 | `--mlflow-run-id TEXT` | unset | Resume an existing MLflow run |
 | `--data-generation-experiment-id TEXT` | unset | Derive the data location and lineage from an MLflow experiment |
 | `--mlflow-tracking-uri TEXT` | `MLFLOW_TRACKING_URI` or `sqlite:///mlflow.db` | MLflow tracking backend |
-| `--mlflow-artifact-location TEXT` | `MLFLOW_ARTIFACT_LOCATION` or `./mlruns` | MLflow artifact root |
+| `--mlflow-artifact-location TEXT` | `MLFLOW_ARTIFACT_LOCATION` or MLflow's default | Artifact root for a newly created experiment; local paths are made absolute, URIs (`s3://`, `gs://`, …) pass through. Omit when the server proxies artifacts |
 | `--log-level LEVEL`, `-l LEVEL` | `WARNING` | Logging threshold |
 
 ## `torchtrain`
@@ -41,12 +42,13 @@ Train a PyTorch network. Its data-discovery and MLflow options match
 | `--network-id INTEGER` | `0` | Network entry selected from the configuration |
 | `--dl-workers INTEGER` | `1` | DataLoader worker count; non-positive values request automatic sizing |
 | `--dry-run` | off | Validate configuration and data discovery without training |
+| `--mlflow` / `--no-mlflow` | auto | Force tracking on or off; when omitted, tracking is on if any `--mlflow-*` option, `--data-generation-experiment-id`, or `MLFLOW_TRACKING_URI` is set |
 | `--mlflow-run-name TEXT` | unset | Enable tracking under this run name |
 | `--mlflow-experiment-name TEXT` | `MLFLOW_EXPERIMENT_NAME` or unset | MLflow experiment name |
 | `--mlflow-run-id TEXT` | unset | Resume an existing MLflow run |
 | `--data-generation-experiment-id TEXT` | unset | Derive the data location and lineage from an MLflow experiment |
 | `--mlflow-tracking-uri TEXT` | `MLFLOW_TRACKING_URI` or `sqlite:///mlflow.db` | MLflow tracking backend |
-| `--mlflow-artifact-location TEXT` | `MLFLOW_ARTIFACT_LOCATION` or `./mlruns` | MLflow artifact root |
+| `--mlflow-artifact-location TEXT` | `MLFLOW_ARTIFACT_LOCATION` or MLflow's default | Artifact root for a newly created experiment; local paths are made absolute, URIs (`s3://`, `gs://`, …) pass through. Omit when the server proxies artifacts |
 | `--log-level LEVEL`, `-l LEVEL` | `WARNING` | Logging threshold |
 
 ## `transform-onnx`

--- a/docs/using_mlflow.md
+++ b/docs/using_mlflow.md
@@ -471,5 +471,8 @@ pip install --upgrade mlflow
 
 ## 📚 See Also
 
+- Canonical run schema (params, tags, artifacts per phase, lineage joins) and the
+  shared lab MLflow server setup: `_docs/mlflow-schema.md` and
+  `_docs/mlflow-deployment.md` in the HSSMSpine repository
 - [MLflow Documentation](https://mlflow.org/docs/latest/index.html)
 - [MLflow Tracking](https://mlflow.org/docs/latest/tracking.html)

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -29,6 +29,8 @@ import typer
 from lanfactory.cli.utils import (
     _get_train_network_config,
     log_training_run_identity,
+    resolve_mlflow_artifact_location,
+    resolve_mlflow_tracking_enabled,
 )
 from torch.utils.data import DataLoader
 
@@ -58,6 +60,13 @@ def main(
         "--export-onnx/--no-export-onnx",
         help="Export the trained network to ONNX (single-trial contract) "
         "alongside the flax state. ONNX is the artifact HSSM consumes.",
+    ),
+    mlflow_enabled: bool = typer.Option(
+        None,
+        "--mlflow/--no-mlflow",
+        help="Force MLflow tracking on or off. When omitted, tracking is enabled "
+        "if any --mlflow-* option or --data-generation-experiment-id is given, "
+        "or if MLFLOW_TRACKING_URI is set in the environment.",
     ),
     mlflow_run_name: str = typer.Option(
         None,
@@ -90,8 +99,9 @@ def main(
     mlflow_artifact_location: str = typer.Option(
         None,
         "--mlflow-artifact-location",
-        help="Root directory for MLflow artifacts. "
-        "Defaults to MLFLOW_ARTIFACT_LOCATION env var, then './mlruns'.",
+        help="Artifact root for a newly created experiment (local path or URI such "
+        "as s3://…). Defaults to MLFLOW_ARTIFACT_LOCATION env var, then MLflow's "
+        "default. Omit when the tracking server proxies artifacts.",
     ),
     log_level: str = typer.Option(
         "WARNING",
@@ -157,12 +167,16 @@ def main(
             "Cannot proceed without a data source."
         )
 
-    # Determine if MLflow tracking should be enabled
-    # Enable if: --mlflow-run-name provided OR --mlflow-run-id provided OR --data-generation-experiment-id provided
-    mlflow_tracking_enabled = (
-        mlflow_run_name is not None
-        or mlflow_run_id is not None
-        or data_generation_experiment_id is not None
+    # Determine if MLflow tracking should be enabled: --mlflow/--no-mlflow wins;
+    # otherwise any tracking option, or MLFLOW_TRACKING_URI in the env, turns it on.
+    import os
+
+    mlflow_tracking_enabled = resolve_mlflow_tracking_enabled(
+        mlflow_flag=mlflow_enabled,
+        mlflow_run_name=mlflow_run_name,
+        mlflow_run_id=mlflow_run_id,
+        data_generation_experiment_id=data_generation_experiment_id,
+        tracking_uri_env=os.getenv("MLFLOW_TRACKING_URI"),
     )
 
     # Initialize MLflow if needed
@@ -195,10 +209,9 @@ def main(
                 else:
                     artifact_location = os.getenv("MLFLOW_ARTIFACT_LOCATION", None)
 
+                # Local paths become absolute; URIs (s3://, gs://, …) pass through.
+                artifact_location = resolve_mlflow_artifact_location(artifact_location)
                 if artifact_location:
-                    # Ensure artifact location is absolute path
-                    artifact_location = str(Path(artifact_location).absolute())
-
                     # Try to get existing experiment, or create new one with artifact location
                     experiment = mlflow.get_experiment_by_name(mlflow_experiment)
                     if experiment is None:

--- a/src/lanfactory/cli/torch_train.py
+++ b/src/lanfactory/cli/torch_train.py
@@ -30,6 +30,8 @@ import lanfactory
 from lanfactory.cli.utils import (
     _get_train_network_config,
     log_training_run_identity,
+    resolve_mlflow_artifact_location,
+    resolve_mlflow_tracking_enabled,
 )
 
 app = typer.Typer()
@@ -52,6 +54,13 @@ def main(
         "--dry-run",
         help="Validate the pipeline without training. Useful for testing configurations.",
         is_flag=True,
+    ),
+    mlflow_enabled: bool = typer.Option(
+        None,
+        "--mlflow/--no-mlflow",
+        help="Force MLflow tracking on or off. When omitted, tracking is enabled "
+        "if any --mlflow-* option or --data-generation-experiment-id is given, "
+        "or if MLFLOW_TRACKING_URI is set in the environment.",
     ),
     mlflow_run_name: str = typer.Option(
         None,
@@ -84,8 +93,9 @@ def main(
     mlflow_artifact_location: str = typer.Option(
         None,
         "--mlflow-artifact-location",
-        help="Root directory for MLflow artifacts. "
-        "Defaults to MLFLOW_ARTIFACT_LOCATION env var, then './mlruns'.",
+        help="Artifact root for a newly created experiment (local path or URI such "
+        "as s3://…). Defaults to MLFLOW_ARTIFACT_LOCATION env var, then MLflow's "
+        "default. Omit when the tracking server proxies artifacts.",
     ),
     log_level: str = typer.Option(
         "WARNING",
@@ -155,12 +165,16 @@ def main(
             "Cannot proceed without a data source."
         )
 
-    # Determine if MLflow tracking should be enabled
-    # Enable if: --mlflow-run-name provided OR --mlflow-run-id provided OR --data-generation-experiment-id provided
-    mlflow_tracking_enabled = (
-        mlflow_run_name is not None
-        or mlflow_run_id is not None
-        or data_generation_experiment_id is not None
+    # Determine if MLflow tracking should be enabled: --mlflow/--no-mlflow wins;
+    # otherwise any tracking option, or MLFLOW_TRACKING_URI in the env, turns it on.
+    import os
+
+    mlflow_tracking_enabled = resolve_mlflow_tracking_enabled(
+        mlflow_flag=mlflow_enabled,
+        mlflow_run_name=mlflow_run_name,
+        mlflow_run_id=mlflow_run_id,
+        data_generation_experiment_id=data_generation_experiment_id,
+        tracking_uri_env=os.getenv("MLFLOW_TRACKING_URI"),
     )
 
     # Initialize MLflow if needed
@@ -193,10 +207,9 @@ def main(
                 else:
                     artifact_location = os.getenv("MLFLOW_ARTIFACT_LOCATION", None)
 
+                # Local paths become absolute; URIs (s3://, gs://, …) pass through.
+                artifact_location = resolve_mlflow_artifact_location(artifact_location)
                 if artifact_location:
-                    # Ensure artifact location is absolute path
-                    artifact_location = str(Path(artifact_location).absolute())
-
                     # Try to get existing experiment, or create new one with artifact location
                     experiment = mlflow.get_experiment_by_name(mlflow_experiment)
                     if experiment is None:

--- a/src/lanfactory/cli/utils.py
+++ b/src/lanfactory/cli/utils.py
@@ -187,6 +187,53 @@ def _get_train_network_config(yaml_config_path: str | Path | None = None, net_in
     return config
 
 
+def resolve_mlflow_tracking_enabled(
+    *,
+    mlflow_flag: bool | None,
+    mlflow_run_name: str | None,
+    mlflow_run_id: str | None,
+    data_generation_experiment_id: str | None,
+    tracking_uri_env: str | None = None,
+) -> bool:
+    """Decide whether a training CLI should log to MLflow.
+
+    ``--mlflow`` / ``--no-mlflow`` is authoritative when given. Otherwise
+    tracking is enabled implicitly when any tracking-related option
+    (run name, run id, data-generation experiment) is present, **or** when
+    ``MLFLOW_TRACKING_URI`` is set in the environment: a lab that points
+    everyone at a shared server (see HSSMSpine ``_docs/mlflow-deployment.md``)
+    wants every run recorded without each caller remembering a flag.
+    """
+    if mlflow_flag is not None:
+        return mlflow_flag
+    return (
+        mlflow_run_name is not None
+        or mlflow_run_id is not None
+        or data_generation_experiment_id is not None
+        or bool(tracking_uri_env)
+    )
+
+
+def resolve_mlflow_artifact_location(value: str | None) -> str | None:
+    """Normalise an MLflow artifact location for ``create_experiment``.
+
+    Local paths are made absolute so a run launched from a different working
+    directory (or a SLURM job) resolves the same folder. Anything carrying a
+    URI scheme (``s3://``, ``gs://``, ``mlflow-artifacts:/``, ``file:///``…)
+    is returned untouched — wrapping it in ``Path(...).absolute()`` would turn
+    ``s3://bucket/x`` into ``/cwd/s3:/bucket/x``.
+    """
+    if not value:
+        return None
+    from urllib.parse import urlsplit
+
+    scheme = urlsplit(value).scheme
+    # A one-letter scheme is a Windows drive letter, not a URI.
+    if len(scheme) > 1:
+        return value
+    return str(Path(value).absolute())
+
+
 def log_training_run_identity(
     *,
     model: str,

--- a/src/lanfactory/utils/mlflow_utils.py
+++ b/src/lanfactory/utils/mlflow_utils.py
@@ -29,7 +29,10 @@ def get_files_from_data_generation_experiment(
             - num_runs: number of runs in the experiment
             - total_files: total number of files generated
             - all_files: list of all filenames
-            - runs_info: list of dicts with run details
+            - runs_info: list of dicts with run details (``run_id``,
+              ``run_name``, ``num_files``, ``total_size_mb``, ``files``, and
+              ``data_output_folder`` — the folder the data-generation run
+              wrote to, or None if that param was not logged)
 
     Raises
     ------
@@ -82,6 +85,15 @@ def get_files_from_data_generation_experiment(
             run_files = [file_info["filename"] for file_info in inventory["files"]]
             all_files.extend(run_files)
 
+            # ``data_output_folder`` is a param the ssm-simulators ``generate``
+            # CLI logs on every non-dry run; the training CLIs read it from
+            # ``runs_info`` to derive the training-data folder in MLflow-first
+            # mode. ``search_runs`` yields NaN for a missing param, so
+            # normalise that to None.
+            data_output_folder = run.get("params.data_output_folder")
+            if not isinstance(data_output_folder, str):
+                data_output_folder = None
+
             runs_info.append(
                 {
                     "run_id": run_id,
@@ -89,6 +101,7 @@ def get_files_from_data_generation_experiment(
                     "num_files": inventory["num_files"],
                     "total_size_mb": inventory["total_size_mb"],
                     "files": run_files,
+                    "data_output_folder": data_output_folder,
                 }
             )
 

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -4,7 +4,88 @@ from unittest.mock import patch, mock_open
 
 import pytest
 
-from lanfactory.cli.utils import _make_train_network_configs, _get_train_network_config
+from lanfactory.cli.utils import (
+    _get_train_network_config,
+    _make_train_network_configs,
+    resolve_mlflow_artifact_location,
+    resolve_mlflow_tracking_enabled,
+)
+
+
+class TestResolveMlflowTrackingEnabled:
+    _off = dict(
+        mlflow_run_name=None, mlflow_run_id=None, data_generation_experiment_id=None
+    )
+
+    def test_nothing_set_is_disabled(self):
+        assert resolve_mlflow_tracking_enabled(mlflow_flag=None, **self._off) is False
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"mlflow_run_name": "r"},
+            {"mlflow_run_id": "abc"},
+            {"data_generation_experiment_id": "1"},
+        ],
+    )
+    def test_any_tracking_option_enables(self, override):
+        kwargs = {**self._off, **override}
+        assert resolve_mlflow_tracking_enabled(mlflow_flag=None, **kwargs) is True
+
+    def test_tracking_uri_env_enables(self):
+        assert (
+            resolve_mlflow_tracking_enabled(
+                mlflow_flag=None, tracking_uri_env="http://mlflow:5000", **self._off
+            )
+            is True
+        )
+
+    def test_empty_env_does_not_enable(self):
+        assert (
+            resolve_mlflow_tracking_enabled(
+                mlflow_flag=None, tracking_uri_env="", **self._off
+            )
+            is False
+        )
+
+    def test_explicit_flag_wins_both_ways(self):
+        assert (
+            resolve_mlflow_tracking_enabled(
+                mlflow_flag=False,
+                tracking_uri_env="http://x",
+                mlflow_run_name="r",
+                mlflow_run_id=None,
+                data_generation_experiment_id=None,
+            )
+            is False
+        )
+        assert resolve_mlflow_tracking_enabled(mlflow_flag=True, **self._off) is True
+
+
+class TestResolveMlflowArtifactLocation:
+    def test_none_and_empty_pass_through(self):
+        assert resolve_mlflow_artifact_location(None) is None
+        assert resolve_mlflow_artifact_location("") is None
+
+    def test_relative_path_becomes_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert resolve_mlflow_artifact_location("mlruns") == str(tmp_path / "mlruns")
+
+    def test_absolute_path_unchanged(self, tmp_path):
+        assert resolve_mlflow_artifact_location(str(tmp_path)) == str(tmp_path)
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "s3://bucket/prefix",
+            "gs://bucket/prefix",
+            "mlflow-artifacts:/",
+            "file:///oscar/data/lab/mlflow/artifacts",
+            "hdfs://nn:8020/mlflow",
+        ],
+    )
+    def test_uris_pass_through_untouched(self, uri):
+        assert resolve_mlflow_artifact_location(uri) == uri
 
 
 def test_make_train_network_configs_with_dict_args():

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -120,6 +120,9 @@ def mock_data_generation_experiment(test_mlflow_dir):
 
             mlflow.log_dict(file_inventory, "generated_files_inventory.json")
             mlflow.log_param("run_index", i)
+            # ssm-simulators' ``generate`` logs this on every real run; the
+            # training CLIs derive the data folder from it in MLflow-first mode.
+            mlflow.log_param("data_output_folder", "/shared/data/training_data")
 
     return {
         "experiment_id": experiment.experiment_id,
@@ -179,6 +182,28 @@ class TestMLflowUtils:
         expected_files = set(mock_data_generation_experiment["all_files"])
         actual_files = set(result["all_files"])
         assert expected_files == actual_files
+
+        # The training CLIs read ``data_output_folder`` off ``runs_info`` to
+        # locate the data in MLflow-first mode; it must be carried through.
+        for run_info in result["runs_info"]:
+            assert run_info["data_output_folder"] == "/shared/data/training_data"
+
+    def test_runs_without_data_output_folder_yield_none(self, test_mlflow_dir):
+        """A datagen run that never logged the folder param gives None, not NaN."""
+        artifact_location = test_mlflow_dir["artifact_location"]
+        set_experiment_with_artifact_location("no-folder-param", artifact_location)
+        experiment = mlflow.get_experiment_by_name("no-folder-param")
+        with mlflow.start_run():
+            mlflow.log_dict(
+                {"num_files": 0, "total_size_mb": 0.0, "files": []},
+                "generated_files_inventory.json",
+            )
+
+        result = get_files_from_data_generation_experiment(
+            experiment_id=experiment.experiment_id,
+            tracking_uri=test_mlflow_dir["tracking_uri"],
+        )
+        assert result["runs_info"][0]["data_output_folder"] is None
 
     def test_get_files_from_empty_experiment(self, test_mlflow_dir):
         """Test behavior when experiment has no runs."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--mlflow` and `--no-mlflow` options to training commands for explicit tracking control.
  - MLflow tracking can now be enabled through `MLFLOW_TRACKING_URI`.
  - Artifact locations now support cloud and server-based URIs while converting local paths to absolute paths.
  - Data-generation run information now includes the associated data output folder when available.

- **Documentation**
  - Updated CLI references with MLflow options and artifact-location behavior.
  - Added references to MLflow run schema and shared server setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->