### PR TITLE
Feat/mlflow schema v2

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -26,6 +26,7 @@ Train a JAX network. Either `--training-data-folder` or
 | `--mlflow-run-id TEXT` | unset | Resume an existing MLflow run |
 | `--data-generation-experiment-id TEXT` | unset | Derive the data location and lineage from an MLflow experiment |
 | `--mlflow-tracking-uri TEXT` | `MLFLOW_TRACKING_URI` or `sqlite:///mlflow.db` | MLflow tracking backend |
+| `--lineage-id TEXT` | training pickles, then datagen runs' tag, then a fresh UUID | Lineage id tagged on the run and stored in the config pickles; links the network to its data and to later HSSM fits |
 | `--mlflow-artifact-location TEXT` | `MLFLOW_ARTIFACT_LOCATION` or MLflow's default | Artifact root for a newly created experiment; local paths are made absolute, URIs (`s3://`, `gs://`, …) pass through. Omit when the server proxies artifacts |
 | `--log-level LEVEL`, `-l LEVEL` | `WARNING` | Logging threshold |
 
@@ -48,6 +49,7 @@ Train a PyTorch network. Its data-discovery and MLflow options match
 | `--mlflow-run-id TEXT` | unset | Resume an existing MLflow run |
 | `--data-generation-experiment-id TEXT` | unset | Derive the data location and lineage from an MLflow experiment |
 | `--mlflow-tracking-uri TEXT` | `MLFLOW_TRACKING_URI` or `sqlite:///mlflow.db` | MLflow tracking backend |
+| `--lineage-id TEXT` | training pickles, then datagen runs' tag, then a fresh UUID | Lineage id tagged on the run and stored in the config pickles; links the network to its data and to later HSSM fits |
 | `--mlflow-artifact-location TEXT` | `MLFLOW_ARTIFACT_LOCATION` or MLflow's default | Artifact root for a newly created experiment; local paths are made absolute, URIs (`s3://`, `gs://`, …) pass through. Omit when the server proxies artifacts |
 | `--log-level LEVEL`, `-l LEVEL` | `WARNING` | Logging threshold |
 

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -27,10 +27,12 @@ import lanfactory
 import psutil
 import typer
 from lanfactory.cli.utils import (
+    LINEAGE_ID_KEY,
     _get_train_network_config,
     log_training_run_identity,
     resolve_mlflow_artifact_location,
     resolve_mlflow_tracking_enabled,
+    resolve_training_lineage_id,
 )
 from torch.utils.data import DataLoader
 
@@ -102,6 +104,14 @@ def main(
         help="Artifact root for a newly created experiment (local path or URI such "
         "as s3://…). Defaults to MLFLOW_ARTIFACT_LOCATION env var, then MLflow's "
         "default. Omit when the tracking server proxies artifacts.",
+    ),
+    lineage_id: str = typer.Option(
+        None,
+        "--lineage-id",
+        help="Identifier linking this network to the data it was trained on and "
+        "to later HSSM fits (MLflow tag `lineage_id`, stored in the train and "
+        "network config pickles). Defaults to the id in the training pickles, "
+        "then the data-generation runs' tag, then a fresh UUID.",
     ),
     log_level: str = typer.Option(
         "WARNING",
@@ -185,8 +195,9 @@ def main(
 
     if mlflow_tracking_enabled:
         try:
-            import mlflow
             import os
+
+            import mlflow
 
             # Set tracking URI with priority: CLI arg > env var > default
             if mlflow_tracking_uri:
@@ -247,6 +258,19 @@ def main(
             logger.error("Failed to initialize MLflow: %s", e)
             mlflow_tracking_enabled = False
 
+    # Record the MLflow run this training belongs to inside train_config, so the
+    # pickled config (and the HF manifest built from it) can point back here.
+    if mlflow_tracking_enabled:
+        try:
+            import mlflow
+
+            active = mlflow.active_run()
+            if active is not None:
+                train_config["mlflow_run_id"] = active.info.run_id
+                train_config["mlflow_tracking_uri"] = mlflow.get_tracking_uri()
+        except Exception as e:  # noqa: BLE001 - tracking must never kill training
+            logger.error("Failed to record MLflow run id in train_config: %s", e)
+
     # Get data lineage information if experiment ID provided
     if data_generation_experiment_id:
         try:
@@ -254,8 +278,9 @@ def main(
 
             if not mlflow_tracking_enabled:
                 # Need to initialize MLflow just for querying
-                import mlflow
                 import os
+
+                import mlflow
 
                 # Use same logic as above for tracking URI
                 if mlflow_tracking_uri:
@@ -466,6 +491,18 @@ def main(
     # Generate unique run_id for file naming (independent of MLflow run_id)
     RUN_ID = uuid.uuid1().hex
 
+    # Lineage id: CLI > training pickles > datagen runs' tag > minted. Stamped
+    # into both config pickles so upload-hf and HSSM can recover it offline.
+    lineage_runs = (mlflow_lineage_info or {}).get("runs_info") or []
+    lineage_id, lineage_source = resolve_training_lineage_id(
+        explicit=lineage_id,
+        dataset=train_dataset,
+        data_generation_runs=lineage_runs,
+    )
+    logger.info("Lineage id: %s (source: %s)", lineage_id, lineage_source)
+    network_config[LINEAGE_ID_KEY] = lineage_id
+    train_config[LINEAGE_ID_KEY] = lineage_id
+
     # save network config for this run
     networks_path = (
         Path(networks_path_base)
@@ -503,6 +540,8 @@ def main(
             training_data_folder=training_data_folder,
             n_training_files=n_training_files,
             dataset=train_dataset,
+            lineage_id=lineage_id,
+            data_generation_run_ids=[r["run_id"] for r in lineage_runs] or None,
         )
         try:
             import mlflow

--- a/src/lanfactory/cli/torch_train.py
+++ b/src/lanfactory/cli/torch_train.py
@@ -22,16 +22,17 @@ from copy import deepcopy
 from importlib.resources import as_file, files
 from pathlib import Path
 
+import lanfactory
 import psutil
 import torch
 import typer
-
-import lanfactory
 from lanfactory.cli.utils import (
+    LINEAGE_ID_KEY,
     _get_train_network_config,
     log_training_run_identity,
     resolve_mlflow_artifact_location,
     resolve_mlflow_tracking_enabled,
+    resolve_training_lineage_id,
 )
 
 app = typer.Typer()
@@ -96,6 +97,14 @@ def main(
         help="Artifact root for a newly created experiment (local path or URI such "
         "as s3://…). Defaults to MLFLOW_ARTIFACT_LOCATION env var, then MLflow's "
         "default. Omit when the tracking server proxies artifacts.",
+    ),
+    lineage_id: str = typer.Option(
+        None,
+        "--lineage-id",
+        help="Identifier linking this network to the data it was trained on and "
+        "to later HSSM fits (MLflow tag `lineage_id`, stored in the train and "
+        "network config pickles). Defaults to the id in the training pickles, "
+        "then the data-generation runs' tag, then a fresh UUID.",
     ),
     log_level: str = typer.Option(
         "WARNING",
@@ -183,8 +192,9 @@ def main(
 
     if mlflow_tracking_enabled:
         try:
-            import mlflow
             import os
+
+            import mlflow
 
             # Set tracking URI with priority: CLI arg > env var > default
             if mlflow_tracking_uri:
@@ -245,6 +255,19 @@ def main(
             logger.error("Failed to initialize MLflow: %s", e)
             mlflow_tracking_enabled = False
 
+    # Record the MLflow run this training belongs to inside train_config, so the
+    # pickled config (and the HF manifest built from it) can point back here.
+    if mlflow_tracking_enabled:
+        try:
+            import mlflow
+
+            active = mlflow.active_run()
+            if active is not None:
+                train_config["mlflow_run_id"] = active.info.run_id
+                train_config["mlflow_tracking_uri"] = mlflow.get_tracking_uri()
+        except Exception as e:  # noqa: BLE001 - tracking must never kill training
+            logger.error("Failed to record MLflow run id in train_config: %s", e)
+
     # Get data lineage information if experiment ID provided
     if data_generation_experiment_id:
         try:
@@ -252,8 +275,9 @@ def main(
 
             if not mlflow_tracking_enabled:
                 # Need to initialize MLflow just for querying
-                import mlflow
                 import os
+
+                import mlflow
 
                 # Use same logic as above for tracking URI
                 if mlflow_tracking_uri:
@@ -464,6 +488,18 @@ def main(
     # Generate unique run_id for file naming (independent of MLflow run_id)
     RUN_ID = uuid.uuid1().hex
 
+    # Lineage id: CLI > training pickles > datagen runs' tag > minted. Stamped
+    # into both config pickles so upload-hf and HSSM can recover it offline.
+    lineage_runs = (mlflow_lineage_info or {}).get("runs_info") or []
+    lineage_id, lineage_source = resolve_training_lineage_id(
+        explicit=lineage_id,
+        dataset=train_dataset,
+        data_generation_runs=lineage_runs,
+    )
+    logger.info("Lineage id: %s (source: %s)", lineage_id, lineage_source)
+    network_config[LINEAGE_ID_KEY] = lineage_id
+    train_config[LINEAGE_ID_KEY] = lineage_id
+
     # save network config for this run
     networks_path = (
         Path(networks_path_base)
@@ -501,6 +537,8 @@ def main(
             training_data_folder=training_data_folder,
             n_training_files=n_training_files,
             dataset=train_dataset,
+            lineage_id=lineage_id,
+            data_generation_run_ids=[r["run_id"] for r in lineage_runs] or None,
         )
         try:
             import mlflow

--- a/src/lanfactory/cli/utils.py
+++ b/src/lanfactory/cli/utils.py
@@ -234,6 +234,103 @@ def resolve_mlflow_artifact_location(value: str | None) -> str | None:
     return str(Path(value).absolute())
 
 
+# MLflow run-schema version emitted by the training CLIs. Documented in
+# HSSMSpine ``_docs/mlflow-schema.md``; bump together with ssm-simulators.
+MLFLOW_SCHEMA_VERSION = "2"
+
+# Key under which ssm-simulators stamps the lineage id into ``data_config``
+# (and therefore into every training pickle's ``generator_config``), and under
+# which the trainers carry it in ``train_config`` / ``network_config``.
+LINEAGE_ID_KEY = "lineage_id"
+
+
+def _git_sha() -> str | None:
+    """Best-effort commit sha when lanfactory runs from a checkout, else None."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(Path(__file__).resolve().parent), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    sha = result.stdout.strip()
+    return sha if result.returncode == 0 and sha else None
+
+
+def common_run_tags(lineage_id: str) -> dict[str, str]:
+    """Tags every phase of the schema carries (v2 "common" block)."""
+    import getpass
+    import socket
+
+    tags = {
+        "schema_version": MLFLOW_SCHEMA_VERSION,
+        LINEAGE_ID_KEY: lineage_id,
+        "hostname": socket.gethostname(),
+    }
+    try:
+        tags["user"] = getpass.getuser()
+    except (KeyError, OSError):  # no passwd entry in some containers
+        pass
+    if sha := _git_sha():
+        tags["git_sha"] = sha
+    return tags
+
+
+def resolve_training_lineage_id(
+    *,
+    explicit: str | None,
+    dataset=None,
+    data_generation_runs: list[dict] | None = None,
+) -> tuple[str, str]:
+    """Pick the lineage id for a training run and say where it came from.
+
+    Precedence: ``--lineage-id`` > the id ssm-simulators stamped into the
+    training pickles (``generator_config["lineage_id"]``, read via the dataset)
+    > the ``lineage_id`` tag of the data-generation runs (MLflow lineage mode)
+    > a freshly minted UUID4 hex. Legacy data therefore still gets an id, so
+    the network -> fit half of the chain works even when the data half is
+    unknown (user decision, 2026-09).
+
+    Returns ``(lineage_id, source)`` with ``source`` one of ``"cli"``,
+    ``"training_data"``, ``"data_generation_runs"``, ``"minted"``.
+    """
+    import uuid
+
+    if explicit is not None and explicit.strip():
+        return explicit.strip(), "cli"
+
+    generator_config = getattr(dataset, "data_generator_config", None)
+    if isinstance(generator_config, dict):
+        from_data = generator_config.get(LINEAGE_ID_KEY)
+        if isinstance(from_data, str) and from_data:
+            return from_data, "training_data"
+
+    ids = [
+        r.get(LINEAGE_ID_KEY)
+        for r in (data_generation_runs or [])
+        if isinstance(r.get(LINEAGE_ID_KEY), str) and r.get(LINEAGE_ID_KEY)
+    ]
+    if ids:
+        distinct = sorted(set(ids))
+        if len(distinct) > 1:
+            logger.warning(
+                "Data-generation runs carry %d distinct lineage ids %s; "
+                "using the most recent run's (%s). Pass --lineage-id to "
+                "override.",
+                len(distinct),
+                distinct,
+                ids[0],
+            )
+        return ids[0], "data_generation_runs"
+
+    return uuid.uuid4().hex, "minted"
+
+
 def log_training_run_identity(
     *,
     model: str,
@@ -244,6 +341,8 @@ def log_training_run_identity(
     training_data_folder: Path | str | None,
     n_training_files: int,
     dataset=None,
+    lineage_id: str | None = None,
+    data_generation_run_ids: list[str] | None = None,
 ) -> None:
     """Log identity params/tags that make a training run self-describing.
 
@@ -270,6 +369,16 @@ def log_training_run_identity(
     trainer separately bulk-logs ``train_config`` whose ``n_training_files``
     is the configured *cap*, and reusing that param key with the effective
     value would make MLflow reject the trainer's entire param batch.
+
+    Schema v2 adds the common block (``schema_version="2"``, ``lineage_id``,
+    ``user``, ``hostname``, ``git_sha``) and the ``data_generation_run_ids``
+    tag. A missing ``lineage_id`` is minted so the tag is never absent.
+
+    Architecture (``layer_sizes``, ``activations``, ``train_output_type``) is
+    deliberately *not* logged here: those keys live in ``train_config`` and the
+    trainer bulk-logs them. Logging them again with a different encoding makes
+    MLflow reject the trainer's entire param batch (same trap as
+    ``n_training_files`` above).
 
     Best-effort: failures are logged, never raised — training must not die on
     a tracking hiccup. No-op when no MLflow run is active.
@@ -314,12 +423,18 @@ def log_training_run_identity(
 
         mlflow.log_params(params)
 
-        tags = {
-            "schema_version": "1",
-            "phase": "train",
-            "run_uuid": run_uuid,
-            "n_training_files_used": str(n_training_files),
-        }
+        if lineage_id is None:
+            lineage_id, _ = resolve_training_lineage_id(explicit=None, dataset=dataset)
+        tags = common_run_tags(lineage_id)
+        tags.update(
+            {
+                "phase": "train",
+                "run_uuid": run_uuid,
+                "n_training_files_used": str(n_training_files),
+            }
+        )
+        if data_generation_run_ids:
+            tags["data_generation_run_ids"] = ",".join(data_generation_run_ids)
         if training_data_folder is not None:
             tags["training_data_folder"] = str(training_data_folder)
         if config_path is not None and Path(config_path).is_file():

--- a/src/lanfactory/hf/upload.py
+++ b/src/lanfactory/hf/upload.py
@@ -6,6 +6,7 @@ to HuggingFace Hub with proper organization and metadata.
 
 import json
 import logging
+import pickle
 import re
 import tempfile
 from pathlib import Path
@@ -39,7 +40,7 @@ ROOT_ONNX_SUFFIX = {
 }
 
 MANIFEST_FILENAME = "manifest.json"
-MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_VERSION = 2
 
 
 def canonical_root_filename(network_type: str, model_name: str) -> str:
@@ -79,9 +80,68 @@ def validate_model_name(model_name: str) -> None:
 # publishes one model's weights under another's root filename.
 _NT = "lan|cpn|opn|gonogo"
 _ARTIFACT_NAME_PATTERNS = (
-    re.compile(rf"^[^_]+_(?:{_NT})_(?P<model>.+?)__"),  # jax
-    re.compile(rf"^(?P<model>.+?)_(?:{_NT})_[^_]+_"),  # torch
+    re.compile(rf"^(?P<run_uuid>[^_]+)_(?:{_NT})_(?P<model>.+?)__"),  # jax
+    re.compile(rf"^(?P<model>.+?)_(?:{_NT})_(?P<run_uuid>[^_]+)_"),  # torch
 )
+
+
+def run_uuid_from_filename(filename: str) -> str | None:
+    """The trainer ``run_uuid`` embedded in an artifact name, or None.
+
+    This is the MLflow ``tags.run_uuid`` join key: the only identifier both
+    the on-disk / HF artifact set and the training run share.
+    """
+    for pattern in _ARTIFACT_NAME_PATTERNS:
+        if match := pattern.match(filename):
+            return match.group("run_uuid")
+    return None
+
+
+# train_config keys the trainers stamp for provenance (schema v2) and the
+# manifest field each is published under.
+_PROVENANCE_KEYS = ("lineage_id", "mlflow_run_id", "mlflow_tracking_uri")
+
+
+def provenance_from_artifacts(
+    files: list[Path], canonical_onnx: Path | None = None
+) -> dict[str, str]:
+    """Extra manifest fields tying a published network to its MLflow lineage.
+
+    Reads ``lineage_id`` / ``mlflow_run_id`` / ``mlflow_tracking_uri`` from the
+    single ``*_train_config.pickle`` in the artifact set (written by the
+    trainers; schema v2) and ``run_uuid`` from the canonical ONNX filename.
+    Anything unavailable is simply omitted, so legacy artifact sets still
+    publish — with a smaller entry. Never raises.
+    """
+    extra: dict[str, str] = {}
+
+    name_source = canonical_onnx or next(
+        (f for f in files if f.suffix == ".onnx"), None
+    )
+    if name_source is not None and (uuid := run_uuid_from_filename(name_source.name)):
+        extra["run_uuid"] = uuid
+
+    train_configs = [f for f in files if f.name.endswith("_train_config.pickle")]
+    if len(train_configs) != 1:
+        if len(train_configs) > 1:
+            logger.warning(
+                "Multiple train_config pickles in the artifact set %s; not "
+                "recording lineage in the manifest.",
+                [f.name for f in train_configs],
+            )
+        return extra
+    try:
+        with open(train_configs[0], "rb") as f:
+            train_config = pickle.load(f)  # noqa: S301 - our own trainer output
+    except Exception as e:  # noqa: BLE001 - provenance is best-effort
+        logger.warning("Could not read %s for provenance: %s", train_configs[0], e)
+        return extra
+    if isinstance(train_config, dict):
+        for key in _PROVENANCE_KEYS:
+            value = train_config.get(key)
+            if isinstance(value, str) and value:
+                extra[key] = value
+    return extra
 
 
 def names_model(filename: str, model_name: str) -> bool:
@@ -144,7 +204,12 @@ def build_manifest_entry(
     files: list[Path],
     extra: dict | None = None,
 ) -> dict:
-    """One manifest record describing a published network."""
+    """One manifest record describing a published network.
+
+    ``extra`` carries the schema-2 provenance fields (``lineage_id``,
+    ``mlflow_run_id``, ``mlflow_tracking_uri``, ``run_uuid``), see
+    :func:`provenance_from_artifacts`.
+    """
     entry = {
         "model": model_name,
         "network_type": network_type,
@@ -527,7 +592,8 @@ def _upload_to_hf(  # pragma: no cover
 ) -> str:
     """HF-dependent implementation of upload_model."""
     try:
-        from huggingface_hub import HfApi, create_repo as hf_create_repo
+        from huggingface_hub import HfApi
+        from huggingface_hub import create_repo as hf_create_repo
     except ImportError as exc:
         raise ImportError(
             "huggingface_hub is required for HuggingFace uploads. "
@@ -614,6 +680,8 @@ def _upload_to_hf(  # pragma: no cover
                 or existing_root_filename(existing_manifest, network_type, model_name),
                 folder_path=path_in_repo,
                 files=files_to_upload,
+                # lineage_id / mlflow_run_id / run_uuid: the HF -> MLflow join.
+                extra=provenance_from_artifacts(files_to_upload, root_source),
             )
             manifest_path = tmp_path / MANIFEST_FILENAME
             with open(manifest_path, "w") as f:

--- a/src/lanfactory/utils/mlflow_utils.py
+++ b/src/lanfactory/utils/mlflow_utils.py
@@ -32,7 +32,8 @@ def get_files_from_data_generation_experiment(
             - runs_info: list of dicts with run details (``run_id``,
               ``run_name``, ``num_files``, ``total_size_mb``, ``files``, and
               ``data_output_folder`` — the folder the data-generation run
-              wrote to, or None if that param was not logged)
+              wrote to, or None if that param was not logged — and
+              ``lineage_id``, the schema-v2 tag or None)
 
     Raises
     ------
@@ -94,8 +95,14 @@ def get_files_from_data_generation_experiment(
             if not isinstance(data_output_folder, str):
                 data_output_folder = None
 
+            # Schema v2 datagen runs tag their lineage id; None for v1 runs.
+            lineage_id = run.get("tags.lineage_id")
+            if not isinstance(lineage_id, str) or not lineage_id:
+                lineage_id = None
+
             runs_info.append(
                 {
+                    "lineage_id": lineage_id,
                     "run_id": run_id,
                     "run_name": run.get("tags.mlflow.runName", "unknown"),
                     "num_files": inventory["num_files"],

--- a/tests/hf/test_dual_layout.py
+++ b/tests/hf/test_dual_layout.py
@@ -12,15 +12,17 @@ from pathlib import Path
 
 import pytest
 import yaml
-
 from lanfactory.hf.upload import (
     MANIFEST_FILENAME,
+    MANIFEST_SCHEMA_VERSION,
     ROOT_ONNX_SUFFIX,
     build_manifest_entry,
     canonical_root_filename,
     merge_manifest,
     names_model,
     plan_upload_placements,
+    provenance_from_artifacts,
+    run_uuid_from_filename,
     select_canonical_onnx,
     upload_model,
     write_default_model_card,
@@ -219,7 +221,7 @@ class TestManifestMerge:
 
     def test_creates_manifest_from_nothing(self):
         merged = merge_manifest(None, self.entry())
-        assert merged["schema_version"] == 1
+        assert merged["schema_version"] == MANIFEST_SCHEMA_VERSION == 2
         assert [n["model"] for n in merged["networks"]] == ["ddm"]
 
     def test_republish_replaces_rather_than_duplicates(self):
@@ -754,7 +756,6 @@ def test_generated_card_uses_the_artifact_repo_license(tmp_path):
     """franklab/HSSM declares bsd-2-clause; the code is MIT but a model card
     describes the artifact, so a generated card must not contradict the repo."""
     import yaml
-
     from lanfactory.hf import DEFAULT_LICENSE
     from lanfactory.hf.upload import write_default_model_card
 
@@ -763,3 +764,63 @@ def test_generated_card_uses_the_artifact_repo_license(tmp_path):
     write_default_model_card(tmp_path, "lan", "ddm")
     card = yaml.safe_load((tmp_path / "model_card.yaml").read_text())
     assert card["license"] == DEFAULT_LICENSE
+
+
+class TestProvenance:
+    """Schema-2 manifest entries carry the HF -> MLflow join fields."""
+
+    def test_run_uuid_from_both_trainer_conventions(self):
+        assert run_uuid_from_filename("ddm_lan_abc123_model.onnx") == "abc123"  # torch
+        assert run_uuid_from_filename("abc123_lan_ddm__model.onnx") == "abc123"  # jax
+        assert run_uuid_from_filename("model.onnx") is None
+
+    def test_reads_lineage_from_train_config_pickle(self, tmp_path):
+        import pickle
+
+        onnx = tmp_path / "ddm_lan_abc123_model.onnx"
+        onnx.write_bytes(b"x")
+        cfg = tmp_path / "ddm_lan_abc123_train_config.pickle"
+        with open(cfg, "wb") as f:
+            pickle.dump(
+                {
+                    "n_epochs": 2,
+                    "lineage_id": "lin-9",
+                    "mlflow_run_id": "run-9",
+                    "mlflow_tracking_uri": "http://mlflow:5000",
+                },
+                f,
+            )
+        extra = provenance_from_artifacts([onnx, cfg], onnx)
+        assert extra == {
+            "run_uuid": "abc123",
+            "lineage_id": "lin-9",
+            "mlflow_run_id": "run-9",
+            "mlflow_tracking_uri": "http://mlflow:5000",
+        }
+
+    def test_legacy_artifacts_yield_partial_or_empty_extra(self, tmp_path):
+        import pickle
+
+        onnx = tmp_path / "abc_lan_ddm__model.onnx"
+        onnx.write_bytes(b"x")
+        cfg = tmp_path / "abc_lan_ddm__train_config.pickle"
+        with open(cfg, "wb") as f:
+            pickle.dump({"n_epochs": 2}, f)  # v1 trainer: no provenance keys
+        assert provenance_from_artifacts([onnx, cfg], onnx) == {"run_uuid": "abc"}
+        assert provenance_from_artifacts([tmp_path / "model.onnx"]) == {}
+
+    def test_unreadable_pickle_is_ignored(self, tmp_path):
+        cfg = tmp_path / "x_train_config.pickle"
+        cfg.write_bytes(b"not a pickle")
+        assert provenance_from_artifacts([cfg]) == {}
+
+    def test_entry_carries_extra(self):
+        entry = build_manifest_entry(
+            network_type="lan",
+            model_name="ddm",
+            root_filename="ddm.onnx",
+            folder_path="lan/ddm",
+            files=[Path("a.onnx")],
+            extra={"lineage_id": "lin", "run_uuid": "u"},
+        )
+        assert entry["lineage_id"] == "lin" and entry["run_uuid"] == "u"

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,15 +1,71 @@
 """Tests for CLI utilities."""
 
-from unittest.mock import patch, mock_open
+from types import SimpleNamespace
+from unittest.mock import mock_open, patch
 
 import pytest
-
 from lanfactory.cli.utils import (
+    LINEAGE_ID_KEY,
+    MLFLOW_SCHEMA_VERSION,
     _get_train_network_config,
     _make_train_network_configs,
+    common_run_tags,
     resolve_mlflow_artifact_location,
     resolve_mlflow_tracking_enabled,
+    resolve_training_lineage_id,
 )
+
+
+class TestResolveTrainingLineageId:
+    def test_cli_value_wins(self):
+        ds = SimpleNamespace(data_generator_config={LINEAGE_ID_KEY: "data"})
+        runs = [{"run_id": "r", LINEAGE_ID_KEY: "runs"}]
+        assert resolve_training_lineage_id(
+            explicit=" cli ", dataset=ds, data_generation_runs=runs
+        ) == ("cli", "cli")
+
+    def test_training_pickles_beat_datagen_runs(self):
+        ds = SimpleNamespace(data_generator_config={LINEAGE_ID_KEY: "data"})
+        runs = [{"run_id": "r", LINEAGE_ID_KEY: "runs"}]
+        assert resolve_training_lineage_id(
+            explicit=None, dataset=ds, data_generation_runs=runs
+        ) == ("data", "training_data")
+
+    def test_datagen_runs_used_when_data_has_none(self):
+        ds = SimpleNamespace(data_generator_config={"model": "ddm"})
+        runs = [
+            {"run_id": "r1", LINEAGE_ID_KEY: "L"},
+            {"run_id": "r2", LINEAGE_ID_KEY: "L"},
+        ]
+        assert resolve_training_lineage_id(
+            explicit=None, dataset=ds, data_generation_runs=runs
+        ) == ("L", "data_generation_runs")
+
+    def test_conflicting_datagen_ids_take_most_recent_and_warn(self, caplog):
+        runs = [
+            {"run_id": "new", LINEAGE_ID_KEY: "B"},
+            {"run_id": "old", LINEAGE_ID_KEY: "A"},
+        ]
+        with caplog.at_level("WARNING"):
+            lid, src = resolve_training_lineage_id(
+                explicit=None, dataset=None, data_generation_runs=runs
+            )
+        assert (lid, src) == ("B", "data_generation_runs")
+        assert "distinct lineage ids" in caplog.text
+
+    def test_legacy_data_mints(self):
+        ds = SimpleNamespace(data_generator_config="None")  # DatasetTorch default
+        lid, src = resolve_training_lineage_id(explicit=None, dataset=ds)
+        assert src == "minted" and len(lid) == 32
+        assert resolve_training_lineage_id(explicit="", dataset=None)[1] == "minted"
+
+
+def test_common_run_tags_shape():
+    tags = common_run_tags("lin-1")
+    assert tags["schema_version"] == MLFLOW_SCHEMA_VERSION == "2"
+    assert tags[LINEAGE_ID_KEY] == "lin-1"
+    assert tags["hostname"]
+    assert tags.get("git_sha", "x")  # absent outside a checkout, never empty
 
 
 class TestResolveMlflowTrackingEnabled:

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -123,6 +123,7 @@ def mock_data_generation_experiment(test_mlflow_dir):
             # ssm-simulators' ``generate`` logs this on every real run; the
             # training CLIs derive the data folder from it in MLflow-first mode.
             mlflow.log_param("data_output_folder", "/shared/data/training_data")
+            mlflow.set_tag("lineage_id", "datagen-lineage")
 
     return {
         "experiment_id": experiment.experiment_id,
@@ -187,6 +188,7 @@ class TestMLflowUtils:
         # locate the data in MLflow-first mode; it must be carried through.
         for run_info in result["runs_info"]:
             assert run_info["data_output_folder"] == "/shared/data/training_data"
+            assert run_info["lineage_id"] == "datagen-lineage"
 
     def test_runs_without_data_output_folder_yield_none(self, test_mlflow_dir):
         """A datagen run that never logged the folder param gives None, not NaN."""
@@ -204,6 +206,7 @@ class TestMLflowUtils:
             tracking_uri=test_mlflow_dir["tracking_uri"],
         )
         assert result["runs_info"][0]["data_output_folder"] is None
+        assert result["runs_info"][0]["lineage_id"] is None
 
     def test_get_files_from_empty_experiment(self, test_mlflow_dir):
         """Test behavior when experiment has no runs."""

--- a/tests/test_run_identity.py
+++ b/tests/test_run_identity.py
@@ -71,6 +71,8 @@ def make_training_pickle(path: Path, features_key="lan_data", label_key="lan_lab
 
 class TestLogTrainingRunIdentity:
     def _log_and_fetch(self, tmp_tracking, tmp_path, **overrides):
+        """Log identity into a fresh run and return it. ``overrides`` may
+        replace any kwarg of ``log_training_run_identity``."""
         config_yaml = tmp_path / "train.yaml"
         config_yaml.write_text("NETWORK_TYPE: lan\nMODEL: ddm\n")
 
@@ -171,7 +173,7 @@ class TestLogTrainingRunIdentity:
 
     def test_schema_tags(self, tmp_tracking, tmp_path):
         run = self._log_and_fetch(tmp_tracking, tmp_path)
-        assert run.data.tags["schema_version"] == "1"
+        assert run.data.tags["schema_version"] == "2"
         assert run.data.tags["phase"] == "train"
 
     def test_no_dataset_still_logs_core_identity(self, tmp_tracking, tmp_path):
@@ -203,6 +205,67 @@ class TestLogTrainingRunIdentity:
             training_data_folder=None,
             n_training_files=1,
         )
+
+    def test_v2_common_tags_and_minted_lineage(self, tmp_tracking, tmp_path):
+        """No lineage anywhere -> minted uuid; common block always present."""
+        run = self._log_and_fetch(tmp_tracking, tmp_path)
+        tags = run.data.tags
+        assert tags["schema_version"] == "2"
+        assert len(tags["lineage_id"]) == 32
+        int(tags["lineage_id"], 16)
+        assert tags["hostname"]
+        assert tags["user"]
+
+    def test_lineage_id_from_training_pickles(self, tmp_tracking, tmp_path):
+        """The id ssm-simulators stamped into generator_config is reused."""
+        dataset = SimpleNamespace(
+            input_dim=6,
+            data_model_config=MODEL_CONFIG,
+            data_generator_config={"model": "ddm", "lineage_id": "from-data-7"},
+        )
+        run = self._log_and_fetch(tmp_tracking, tmp_path, dataset=dataset)
+        assert run.data.tags["lineage_id"] == "from-data-7"
+
+    def test_explicit_lineage_id_wins(self, tmp_tracking, tmp_path):
+        dataset = SimpleNamespace(
+            input_dim=6,
+            data_model_config=MODEL_CONFIG,
+            data_generator_config={"lineage_id": "from-data"},
+        )
+        run = self._log_and_fetch(
+            tmp_tracking, tmp_path, dataset=dataset, lineage_id="explicit"
+        )
+        assert run.data.tags["lineage_id"] == "explicit"
+
+    def test_datagen_run_ids_tag(self, tmp_tracking, tmp_path):
+        run = self._log_and_fetch(
+            tmp_tracking, tmp_path, data_generation_run_ids=["r1", "r2"]
+        )
+        assert run.data.tags["data_generation_run_ids"] == "r1,r2"
+
+    def test_identity_params_never_collide_with_train_config(
+        self, tmp_tracking, tmp_path
+    ):
+        """The trainer bulk-logs train_config; re-logging any of its keys here
+        with a different encoding makes MLflow reject that whole batch (seen
+        live with ``activations`` during the schema-v2 smoke run)."""
+        from lanfactory.cli.utils import _get_train_network_config
+
+        run = self._log_and_fetch(tmp_tracking, tmp_path)
+        yaml_path = tmp_path / "full.yaml"
+        yaml_path.write_text(
+            "NETWORK_TYPE: lan\nMODEL: ddm\nLAYER_SIZES: [[10, 1]]\n"
+            "ACTIVATIONS: [['tanh']]\nN_EPOCHS: 1\nOPTIMIZER_: adam\n"
+            "N_TRAINING_FILES: 1\nTRAIN_VAL_SPLIT: 0.5\nWEIGHT_DECAY: 0.0\n"
+            "CPU_BATCH_SIZE: 1\nGPU_BATCH_SIZE: 1\nSHUFFLE: true\n"
+            "LABELS_LOWER_BOUND: np.log(1e-7)\nLEARNING_RATE: 0.001\n"
+            "LR_SCHEDULER: reduce_on_plateau\nLR_SCHEDULER_PARAMS: {}\n"
+            "TRAINING_DATA_FOLDER: x\n"
+        )
+        train_config = _get_train_network_config(str(yaml_path), 0)["config_dict"][
+            "train_config"
+        ]
+        assert not set(run.data.params) & set(train_config)
 
 
 class TestDatasetModelConfigRetention:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--lineage-id` option to training commands, linking trained networks with their source data and subsequent analyses.
  - Training runs now record lineage, data-generation references, run identifiers, and tracking details.
  - Uploaded artifacts now include provenance information in manifest schema version 2.

- **Bug Fixes**
  - Improved handling of missing or invalid lineage metadata during data-generation run retrieval.

- **Tests**
  - Expanded coverage for lineage resolution, provenance extraction, and updated run metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->