### PR TITLE
Write training history via iloc (pandas 3 makes DataFrame.values read-only)

### DIFF
--- a/src/lanfactory/trainers/jax_mlp.py
+++ b/src/lanfactory/trainers/jax_mlp.py
@@ -592,7 +592,7 @@ class ModelTrainerJaxMLP:
             )
 
             # Collect loss in training history
-            training_history.values[epoch, :] = [int(epoch), float(test_loss)]
+            training_history.iloc[epoch] = [float(epoch), float(test_loss)]
 
             if self.mlflow_on:
                 try:

--- a/src/lanfactory/trainers/torch_mlp.py
+++ b/src/lanfactory/trainers/torch_mlp.py
@@ -820,7 +820,7 @@ class ModelTrainerTorchMLP:
                     self.scheduler.step()
 
             # Append training history
-            training_history.values[epoch, :] = [epoch, val_loss.cpu()]
+            training_history.iloc[epoch] = [float(epoch), float(val_loss)]
 
             if mlflow_on:
                 try:


### PR DESCRIPTION
- pandas 3.0 (Copy-on-Write by default) returns a read-only array from `DataFrame.values`; both trainers wrote the per-epoch history with `training_history.values[epoch, :] = ...` and raised `ValueError: assignment destination is read-only` (`jax_mlp.py:595`, `torch_mlp.py:823`).
- Any fresh resolution now picks pandas 3.0.5 (no lockfile), so every trainer-backed test — `jaxtrain`/`torchtrain` CLI smoke, `tests/onnx/test_jax_export.py`, `test_jax_mlp.py`, `test_torch_mlp.py` — fails on `main` today; CI resolves fresh as well.
- Fix: assign the row through `iloc` with plain floats. Identical behaviour on pandas 2.x; the `pandas>=2.2.3` floor is unchanged.
- Verified in a fresh env (pandas 3.0.5, numpy 2.5.3, jax 0.11.1, torch 2.14.0): `uv run pytest tests/onnx/test_jax_export.py tests/test_torch_mlp.py tests/test_jax_mlp.py -q --no-cov` passes; `ruff check src && ruff format --check src` clean. The existing end-to-end trainer tests are the regression check.
- Found while preparing the derive-aux stack (HSSMSpine plan); it unblocks that stack's CI but is independent of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when recording training history across supported training backends.
  * Ensured epoch and validation loss values are stored in a compatible, reliable format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->